### PR TITLE
cli: exit early for --help/--version without starting app

### DIFF
--- a/src/mpd_now_playable/cli.py
+++ b/src/mpd_now_playable/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from collections.abc import Iterable
 
 from rich import print
@@ -22,7 +23,23 @@ async def listen(
 	await listener.loop(receivers)
 
 
+def print_help() -> None:
+	print("Usage: mpd-now-playable [OPTIONS]")
+	print("")
+	print("Options:")
+	print("  -h, --help     Show this help message and exit.")
+	print("  -v, --version  Show version and exit.")
+
+
 def main() -> None:
+	args = set(sys.argv[1:])
+	if "-h" in args or "--help" in args:
+		print_help()
+		return
+	if "-v" in args or "--version" in args:
+		print(f"mpd-now-playable v{__version__}")
+		return
+
 	print(f"mpd-now-playable v{__version__}")
 	config = loadConfig()
 	print(config)


### PR DESCRIPTION
The CLI previously always started full app initialization (config load, listener setup, receiver construction, and debug output) even when invoked with `-h`, `--help`, `-v`, or `--version`. That made basic introspection noisy and buried the requested output in startup logs.

Add early argument checks in `main()` so help/version requests are handled immediately and the process exits without starting the app. Introduce a small `print_help()` helper for consistent usage output.

This improves terminal UX and makes debugging/invocation checks much clearer by keeping `-h` and `-v` output focused and predictable.

<img width="560" height="146" alt="image" src="https://github.com/user-attachments/assets/428852b9-67ef-4b08-b8be-584a0b468055" />
