### PR TITLE
fix(launchd): run mpd-now-playable via zsh to expand $HOME in ProgramArguments

### DIFF
--- a/me.00dani.mpd-now-playable.plist
+++ b/me.00dani.mpd-now-playable.plist
@@ -8,7 +8,9 @@
 	<string>me.00dani.mpd-now-playable</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Users/dani/.local/bin/mpd-now-playable</string>
+		<string>/bin/zsh</string>
+		<string>-c</string>
+		<string>$HOME/.local/bin/mpd-now-playable</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
So it's not fixed to a particular user name. 

The sh wrapper is not ideal, but launchd doesn't seem to have any other friendly method. A different alternative would be to use `/usr/loca/bin/mpd-now-playable` but this path is owned by root.