### PR TITLE
fix(mpd): accept list-valued track tags

### DIFF
--- a/src/mpd_now_playable/mpd/convert/to_song.py
+++ b/src/mpd_now_playable/mpd/convert/to_song.py
@@ -24,6 +24,13 @@ def file_to_url(config: MpdConfig, file: str) -> URL | None:
 	return URL(abs_file.as_uri())
 
 
+def first_maybe_plural(value: str | list[str] | None) -> str | None:
+	values = un_maybe_plural(value)
+	if not values:
+		return None
+	return values[0]
+
+
 def to_song(config: MpdConfig, mpd: MpdState) -> Song | Stopped:
 	state = PlaybackState(mpd.status["state"])
 	if state == PlaybackState.stop:
@@ -42,8 +49,8 @@ def to_song(config: MpdConfig, mpd: MpdState) -> Song | Stopped:
 		album_artist=un_maybe_plural(mpd.current.get("albumartist")),
 		composer=un_maybe_plural(mpd.current.get("composer")),
 		genre=un_maybe_plural(mpd.current.get("genre")),
-		track=option_fmap(int, mpd.current.get("track")),
-		disc=option_fmap(int, mpd.current.get("disc")),
+		track=option_fmap(int, first_maybe_plural(mpd.current.get("track"))),
+		disc=option_fmap(int, first_maybe_plural(mpd.current.get("disc"))),
 		duration=option_fmap(float, mpd.status.get("duration")),
 		elapsed=float(mpd.status["elapsed"]),
 		musicbrainz=to_brainz(mpd.current),

--- a/src/mpd_now_playable/mpd/types.py
+++ b/src/mpd_now_playable/mpd/types.py
@@ -78,11 +78,11 @@ class CurrentSongTags(MusicBrainzTags, total=False):
 	albumartistsort: MaybePlural[str]
 	title: str
 	album: MaybePlural[str]
-	track: str
+	track: MaybePlural[str]
 	date: str
 	originaldate: str
 	composer: MaybePlural[str]
-	disc: str
+	disc: MaybePlural[str]
 	label: str
 	genre: MaybePlural[str]
 

--- a/tests/test_mpd_to_song.py
+++ b/tests/test_mpd_to_song.py
@@ -1,0 +1,20 @@
+from mpd_now_playable.config.model import MpdConfig
+from mpd_now_playable.mpd.convert.to_song import to_song
+from mpd_now_playable.mpd.types import MpdState
+
+
+def test_to_song_accepts_single_value_track_and_disc_lists() -> None:
+	mpd = MpdState(
+		status={"state": "play", "elapsed": "1.25", "duration": "3.5"},
+		current={
+			"file": "Artist/Album/Track.flac",
+			"pos": "0",
+			"track": ["7"],
+			"disc": ["2"],
+		},
+	)
+
+	song = to_song(MpdConfig(), mpd)
+
+	assert song.track == 7
+	assert song.disc == 2


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Normalize MPD `track` and `disc` metadata through the existing maybe-plural helper before numeric conversion.
- Accept single-value list responses such as `["7"]` / `["2"]` while preserving existing string tag behavior.
- Add a regression test for list-valued track/disc tags.

## Related Issues / Closes
Closes #10

## Testing
- RED: `uv run --python 3.14 --with pytest --with pydantic --with yarl --with boltons --with ormsgpack --with xdg-base-dirs --with python-mpd2 pytest tests/test_mpd_to_song.py -q` failed before the fix with `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'`.
- `uv run --python 3.14 pytest tests/test_mpd_to_song.py -q` — passed.
- `uv run --python 3.14 pytest tests -q` — passed.
- `uv run --python 3.14 ruff check src/mpd_now_playable` — passed.
- `uv run --python 3.14 --with websockets mypy -p mpd_now_playable` — passed.
- `git diff --check` — passed.

## AI assistance disclosure
This draft PR was prepared by Hermes Agent as an automated maintainer-assist change. I verified the issue state, checked for duplicate PRs, made a minimal regression-tested fix, and opened it as a draft for maintainer review.
